### PR TITLE
Simplify the process

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,34 @@ machine. This is pretty much a few packages which, for one reason or
 another, aren't the best fit for going into Homebrew itself.
  
 ## Installation
-    brew install https://raw2.github.com/leedm777/homebrew-asterisk/master/iksemel.rb
-    brew install homebrew/dupes/ncurses
-    brew install https://raw2.github.com/leedm777/homebrew-asterisk/master/asterisk.rb
+    xcode-select --install
+    brew tap leedm777/homebrew-asterisk
+    brew install asterisk
 
-Add an asterisk group and user:
+## Add an asterisk group and user:
 
     sudo dseditgroup -o create asterisk
     sudo dscl . create /Users/asterisk
     sudo dseditgroup -o edit -a asterisk -t user asterisk
 
-Follow the instructions in the "Using launchd" section [here][voip-info], but replace /usr/local/asterisk/sbin/asterisk with /usr/local/Cellar/asterisk/12.0.0/sbin/asterisk
+## Make some directories not created during install
 
-## Usage
+    mkdir -p /usr/local/Cellar/asterisk/13/etc/asterisk
+    mkdir -p /usr/local/Cellar/asterisk/13/var/run/asterisk
+
+## Get the asterisk-basic configs from github 
+## (Optional if you already have your own configs, but make for an easy start)
+
+    git clone https://github.com/matt-jordan/asterisk-configs.git
+    cp asterisk-configs/asterisk-13/*.conf /usr/local/Cellar/asterisk/13/etc/asterisk/
+    Edit /usr/local/Cellar/asterisk/13/etc/asterisk/asterisk.conf and update necessary
+    lines. A suggested basic diff is in asterisk.conf.diff.
+
+## Copy launchctl file
+
+    sudo cp org.asterisk.asterisk.plist /Library/LaunchDaemons/
+
+## Start Asterisk
 
     launchctl load /Library/LaunchDaemons/org.asterisk.asterisk.plist
 

--- a/asterisk.conf.diff
+++ b/asterisk.conf.diff
@@ -1,0 +1,31 @@
+diff --git a/asterisk-13/asterisk.conf b/asterisk-13/asterisk.conf
+index e4883ec..873c03e 100644
+--- a/asterisk-13/asterisk.conf
++++ b/asterisk-13/asterisk.conf
+@@ -1,15 +1,15 @@
+ [directories](!)
+-astetcdir => /etc/asterisk
+-astmoddir => /usr/lib/asterisk/modules
+-astvarlibdir => /var/lib/asterisk
+-astdbdir => /var/lib/asterisk
+-astkeydir => /var/lib/asterisk
+-astdatadir => /var/lib/asterisk
+-astagidir => /var/lib/asterisk/agi-bin
+-astspooldir => /var/spool/asterisk
+-astrundir => /var/run/asterisk
+-astlogdir => /var/log/asterisk
+-astsbindir => /usr/sbin
++astetcdir => /usr/local/Cellar/asterisk/13/etc/asterisk
++astmoddir => /usr/local/Cellar/asterisk/13/lib/asterisk/modules
++astvarlibdir => /usr/local/Cellar/asterisk/13/var/lib/asterisk
++astdbdir => /usr/local/Cellar/asterisk/13/var/lib/asterisk
++astkeydir => /usr/local/Cellar/asterisk/13/var/lib/asterisk
++astdatadir => /usr/local/Cellar/asterisk/13/var/lib/asterisk
++astagidir => /usr/local/Cellar/asterisk/13/var/lib/asterisk/agi-bin
++astspooldir => /usr/local/Cellar/asterisk/13/var/spool/asterisk
++astrundir => /usr/local/Cellar/asterisk/13/var/run/asterisk
++astlogdir => /usr/local/Cellar/asterisk/13/var/log/asterisk
++astsbindir => /usr/local/Cellar/asterisk/13/sbin
+ 
+ [options]
+ ;verbose = 3

--- a/asterisk.conf.diff
+++ b/asterisk.conf.diff
@@ -3,7 +3,7 @@ index e4883ec..873c03e 100644
 --- a/asterisk-13/asterisk.conf
 +++ b/asterisk-13/asterisk.conf
 @@ -1,15 +1,15 @@
- [directories](!)
+-[directories](!)
 -astetcdir => /etc/asterisk
 -astmoddir => /usr/lib/asterisk/modules
 -astvarlibdir => /var/lib/asterisk
@@ -15,6 +15,7 @@ index e4883ec..873c03e 100644
 -astrundir => /var/run/asterisk
 -astlogdir => /var/log/asterisk
 -astsbindir => /usr/sbin
++[directories]
 +astetcdir => /usr/local/Cellar/asterisk/13/etc/asterisk
 +astmoddir => /usr/local/Cellar/asterisk/13/lib/asterisk/modules
 +astvarlibdir => /usr/local/Cellar/asterisk/13/var/lib/asterisk

--- a/asterisk.rb
+++ b/asterisk.rb
@@ -2,14 +2,14 @@ require 'formula'
 
 class Asterisk < Formula
   homepage 'http://www.asterisk.org'
-  url 'http://downloads.asterisk.org/pub/telephony/asterisk/releases/asterisk-12.2.0.tar.gz'
-  sha1 '80c9e72f658ca171cada93770a53798bf5d7e7d7'
+  url 'http://downloads.asterisk.org/pub/telephony/asterisk/asterisk-13-current.tar.gz'
+  sha1 'be622898815da65542c9a6d5639aba960d7d4798'
 
-  depends_on 'gcc48'
+  depends_on 'homebrew/versions/gcc48'
   depends_on 'gmime'
   depends_on 'iksemel'
   depends_on 'jansson'
-  depends_on 'ncurses'
+  depends_on 'homebrew/dupes/ncurses'
   depends_on 'openssl'
   depends_on 'pjsip-asterisk'
   depends_on 'pkg-config' => :build

--- a/org.asterisk.asterisk.plist
+++ b/org.asterisk.asterisk.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>Disabled</key>
+<false/>
+<key>Label</key>
+<string>com.asterisk.org.asterisk</string>
+<key>ProgramArguments</key>
+<array>
+    <string>/usr/local/Cellar/asterisk/13/sbin/asterisk</string>
+    <string>-f</string>
+    <string>-C</string>
+    <string>/usr/local/Cellar/asterisk/13/etc/asterisk/asterisk.conf</string>
+</array>
+<key>UserName</key>
+<string>asterisk</string>
+<key>GroupName</key>
+<string>asterisk</string>
+<key>OnDemand</key>
+<false/>
+<key>ServiceDescription</key>
+<string>Asterisk PBX</string>
+</dict>
+</plist>


### PR DESCRIPTION
This provides an update to Asterisk-13-current, a little clearer instructions for installing the brew package, as well as a suggested launchctl plist file and instructions on getting Matt Jordan's Asterisk 13 sample configs to get up and running quickly with two extensions. I've tested this on a vanilla OS X install and if you follow the instructions line-by-line, you can have Asterisk installed and running in about 30m, depending on download speeds. May be able to automate some more of the installation process once I figure out how to place the plist file in the right place. Would also like to add the xcode-select --install line to the ruby script, but it seems to throw an error if they're already installed (exiting ruby) and not wait if they're not (meaning the next step fails). 