### PR TITLE
rename EOS.undent to EOS

### DIFF
--- a/asterisk.rb
+++ b/asterisk.rb
@@ -199,7 +199,7 @@ class Asterisk < Formula
 
   plist_options :startup => false, :manual => "asterisk -r"
 
-  def plist; <<-EOS.undent
+  def plist; <<-EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">

--- a/pjsip-asterisk.rb
+++ b/pjsip-asterisk.rb
@@ -20,7 +20,7 @@ class PjsipAsterisk < Formula
     # Build for not-debug
     ENV["CFLAGS"] = "-O2 -DNDEBUG"
 
-    config_site = <<-EOF.undent
+    config_site = <<-EOF
       #include <sys/select.h>
 
       /*


### PR DESCRIPTION
solved the error:

> Error: Failed to install plist file
> Error: Calling <<-EOS.undent is disabled!

on the files:

- /usr/local/Homebrew/Library/Taps/leedm777/homebrew-asterisk/pjsip-asterisk.rb
- /usr/local/Homebrew/Library/Taps/leedm777/homebrew-asterisk/asterisk.rb